### PR TITLE
Update branding to Clinica Magica

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,9 +8,9 @@ import HelloWorld from './components/HelloWorld.vue'
   >
     <section class="mx-auto flex max-w-5xl flex-col gap-16 px-6 py-20 text-center">
       <header class="space-y-6">
-        <p class="text-sm uppercase tracking-[0.4em] text-sky-300/80">Sistema Farma Leado</p>
+        <p class="text-sm uppercase tracking-[0.4em] text-sky-300/80">Sistema Clinica Magica</p>
         <h1 class="text-4xl font-bold leading-tight md:text-5xl">
-          Bienvenido a la plataforma operativa de Farma Leado
+          Bienvenido a la plataforma operativa de Clinica Magica
         </h1>
         <p class="mx-auto max-w-3xl text-lg text-sky-100/80">
           Centraliza tus procesos farmacéuticos con herramientas diseñadas para equipos modernos.
@@ -24,7 +24,7 @@ import HelloWorld from './components/HelloWorld.vue'
             Explorar soluciones
           </button>
           <span class="text-sm text-sky-200/70">
-            Descubre cómo Farma Leado simplifica la gestión farmacéutica.
+            Descubre cómo Clinica Magica simplifica la gestión farmacéutica.
           </span>
         </div>
       </header>

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -31,7 +31,7 @@ const features = [
     <div class="space-y-3 text-center md:text-left">
       <h2 class="text-2xl font-semibold text-sky-100 md:text-3xl">{{ msg }}</h2>
       <p class="text-base text-sky-200/80">
-        Las herramientas de Farma Leado están diseñadas para conectar cada área del negocio farmacéutico y
+        Las herramientas de Clinica Magica están diseñadas para conectar cada área del negocio farmacéutico y
         mantener la operación bajo control.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- replace the Farma Leado branding in the landing page hero with Clinica Magica
- update the HelloWorld component messaging to reference Clinica Magica

## Testing
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68defc8fb404832ca4b504d2158a1157