### PR TITLE
Fix Swagger setup and unauthorized login response

### DIFF
--- a/backend/Backend.csproj
+++ b/backend/Backend.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -119,7 +119,9 @@ app.MapPost("/auth/login", async (LoginRequest request, SqlConnection connection
 
     if (!autenticado || usuario is null)
     {
-        return Results.Unauthorized(new { message = string.IsNullOrWhiteSpace(mensaje) ? "Credenciales inválidas." : mensaje });
+        return Results.Json(
+            new { message = string.IsNullOrWhiteSpace(mensaje) ? "Credenciales inválidas." : mensaje },
+            statusCode: StatusCodes.Status401Unauthorized);
     }
 
     var respuesta = new LoginResponse(


### PR DESCRIPTION
## Summary
- add the Swashbuckle.AspNetCore package so Swagger extensions are available in the backend
- return a 401 JSON response with an error message for failed login attempts

## Testing
- dotnet build Backend.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0d16b0d8832c88003b98cf31d83e