### PR TITLE
Update local API port to 7240

### DIFF
--- a/backend/Properties/launchSettings.json
+++ b/backend/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7240;http://localhost:5240",
+      "applicationUrl": "https://localhost:7240",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -114,7 +114,7 @@ const feedback = computed(() => {
   }
 })
 
-const apiBaseUrl = computed(() => import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000')
+const apiBaseUrl = computed(() => import.meta.env.VITE_API_BASE_URL ?? 'https://localhost:7240')
 
 async function onSubmit() {
   if (isSubmitting.value) return


### PR DESCRIPTION
## Summary
- update the ASP.NET Core launch profile to serve the API on https://localhost:7240
- point the login form's default API base URL to the new local port

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df102ebe28832c90cf532a84307b83