### PR TITLE
Allow CORS for local frontend

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -6,6 +6,20 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("FrontendPolicy", policy =>
+    {
+        policy
+            .WithOrigins(
+                "http://localhost:5173",
+                "https://localhost:5173")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
+
 builder.Services.AddScoped<SqlConnection>(sp =>
 {
     var configuration = sp.GetRequiredService<IConfiguration>();
@@ -26,6 +40,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors("FrontendPolicy");
 
 app.MapGet("/", () =>
     Results.Ok(new { message = "API minimal ASP.NET Core lista." })


### PR DESCRIPTION
## Summary
- add a named CORS policy allowing the Vite dev server origin
- apply the policy so preflight requests succeed for the login endpoint

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df123ce0a0832c8f34125728bdb62c