### PR TITLE
Implement CRUD for medics and users

### DIFF
--- a/frontend/src/services/clinicApi.ts
+++ b/frontend/src/services/clinicApi.ts
@@ -2,8 +2,14 @@ import type {
   Consultation,
   ConsultationHistoryEntry,
   CreateConsultationPayload,
+  CreateMedicPayload,
   CreatePatientPayload,
-  Patient
+  CreateUserPayload,
+  Medic,
+  Patient,
+  UpdateMedicPayload,
+  UpdateUserPayload,
+  UserAccount
 } from '../types'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'https://localhost:7240'
@@ -115,4 +121,72 @@ export async function getConsultationsHistory(
   const queryString = query.toString()
   const path = queryString ? `/consultations?${queryString}` : '/consultations'
   return request<ConsultationHistoryEntry[]>(path, { method: 'GET' })
+}
+
+export async function getMedics(searchTerm?: string, includeInactive = false): Promise<Medic[]> {
+  const query = new URLSearchParams()
+
+  if (searchTerm?.trim()) {
+    query.set('search', searchTerm.trim())
+  }
+
+  if (includeInactive) {
+    query.set('includeInactive', 'true')
+  }
+
+  const queryString = query.toString()
+  const path = queryString ? `/medics?${queryString}` : '/medics'
+  return request<Medic[]>(path, { method: 'GET' })
+}
+
+export async function createMedic(payload: CreateMedicPayload): Promise<Medic> {
+  return request<Medic>('/medics', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
+
+export async function updateMedic(id: number, payload: UpdateMedicPayload): Promise<Medic> {
+  return request<Medic>(`/medics/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload)
+  })
+}
+
+export async function disableMedic(id: number): Promise<void> {
+  await request(`/medics/${id}`, { method: 'DELETE', skipJsonParsing: true })
+}
+
+export async function getUsers(searchTerm?: string, includeInactive = false): Promise<UserAccount[]> {
+  const query = new URLSearchParams()
+
+  if (searchTerm?.trim()) {
+    query.set('search', searchTerm.trim())
+  }
+
+  if (includeInactive) {
+    query.set('includeInactive', 'true')
+  }
+
+  const queryString = query.toString()
+  const path = queryString ? `/users?${queryString}` : '/users'
+  return request<UserAccount[]>(path, { method: 'GET' })
+}
+
+export async function createUser(payload: CreateUserPayload): Promise<UserAccount> {
+  return request<UserAccount>('/users', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
+
+export async function updateUser(id: number, payload: UpdateUserPayload): Promise<UserAccount> {
+  return request<UserAccount>(`/users/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload)
+  })
+}
+
+export async function disableUser(id: number): Promise<void> {
+  await request(`/users/${id}`, { method: 'DELETE', skipJsonParsing: true })
 }

--- a/frontend/src/stores/adminStore.ts
+++ b/frontend/src/stores/adminStore.ts
@@ -1,0 +1,81 @@
+import { computed, ref } from 'vue'
+import * as clinicApi from '../services/clinicApi'
+import type {
+  CreateMedicPayload,
+  CreateUserPayload,
+  Medic,
+  UpdateMedicPayload,
+  UpdateUserPayload,
+  UserAccount
+} from '../types'
+
+const medicsState = ref<Medic[]>([])
+const usersState = ref<UserAccount[]>([])
+
+export function useAdminStore() {
+  const medics = computed(() => medicsState.value)
+  const users = computed(() => usersState.value)
+
+  async function loadMedics(searchTerm = '', includeInactive = false) {
+    const medics = await clinicApi.getMedics(searchTerm, includeInactive)
+    medicsState.value = medics
+    return medics
+  }
+
+  async function createMedic(payload: CreateMedicPayload) {
+    const medic = await clinicApi.createMedic(payload)
+    medicsState.value = [medic, ...medicsState.value.filter((item) => item.id !== medic.id)]
+    return medic
+  }
+
+  async function updateMedic(id: number, payload: UpdateMedicPayload) {
+    const medic = await clinicApi.updateMedic(id, payload)
+    medicsState.value = medicsState.value.map((item) => (item.id === id ? medic : item))
+    return medic
+  }
+
+  async function deactivateMedic(id: number) {
+    await clinicApi.disableMedic(id)
+    medicsState.value = medicsState.value.map((item) =>
+      item.id === id ? { ...item, activo: false } : item
+    )
+  }
+
+  async function loadUsers(searchTerm = '', includeInactive = false) {
+    const users = await clinicApi.getUsers(searchTerm, includeInactive)
+    usersState.value = users
+    return users
+  }
+
+  async function createUser(payload: CreateUserPayload) {
+    const user = await clinicApi.createUser(payload)
+    usersState.value = [user, ...usersState.value.filter((item) => item.id !== user.id)]
+    return user
+  }
+
+  async function updateUser(id: number, payload: UpdateUserPayload) {
+    const user = await clinicApi.updateUser(id, payload)
+    usersState.value = usersState.value.map((item) => (item.id === id ? user : item))
+    return user
+  }
+
+  async function deactivateUser(id: number) {
+    await clinicApi.disableUser(id)
+    usersState.value = usersState.value.map((item) =>
+      item.id === id ? { ...item, activo: false } : item
+    )
+  }
+
+  return {
+    medics,
+    users,
+    loadMedics,
+    createMedic,
+    updateMedic,
+    deactivateMedic,
+    loadUsers,
+    createUser,
+    updateUser,
+    deactivateUser
+  }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,3 +29,57 @@ export interface CreateConsultationPayload {
   notas: string
   fecha?: string
 }
+
+export interface Medic {
+  id: number
+  primerNombre: string
+  segundoNombre?: string | null
+  apellidoPaterno: string
+  apellidoMaterno?: string | null
+  cedula: string
+  especialidad: string
+  email: string
+  telefono?: string | null
+  activo: boolean
+  nombreCompleto: string
+}
+
+export interface CreateMedicPayload {
+  primerNombre: string
+  segundoNombre?: string | null
+  apellidoPaterno: string
+  apellidoMaterno?: string | null
+  cedula: string
+  especialidad: string
+  email: string
+  telefono?: string | null
+}
+
+export interface UpdateMedicPayload extends CreateMedicPayload {
+  activo: boolean
+}
+
+export interface UserAccount {
+  id: number
+  correo: string
+  nombreCompleto: string
+  activo: boolean
+  medicoId?: number | null
+  medicoNombreCompleto?: string | null
+}
+
+export interface CreateUserPayload {
+  correo: string
+  password: string
+  nombreCompleto: string
+  medicoId?: number | null
+  activo: boolean
+}
+
+export interface UpdateUserPayload {
+  correo: string
+  password?: string | null
+  nombreCompleto: string
+  medicoId?: number | null
+  activo: boolean
+}

--- a/frontend/src/views/admin/MedicsAdminView.vue
+++ b/frontend/src/views/admin/MedicsAdminView.vue
@@ -1,25 +1,567 @@
 <script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useAdminStore } from '../../stores/adminStore'
+import type { CreateMedicPayload, Medic, UpdateMedicPayload } from '../../types'
+
+const store = useAdminStore()
+const medics = store.medics
+
+const searchTerm = ref('')
+const includeInactive = ref(false)
+const isLoading = ref(false)
+const loadError = ref<string | null>(null)
+const showCreateForm = ref(false)
+const creationError = ref<string | null>(null)
+const savingNewMedic = ref(false)
+const editingMedicId = ref<number | null>(null)
+const editError = ref<string | null>(null)
+const savingEdit = ref(false)
+const actionInProgressId = ref<number | null>(null)
+
+const newMedic = reactive({
+  primerNombre: '',
+  segundoNombre: '',
+  apellidoPaterno: '',
+  apellidoMaterno: '',
+  cedula: '',
+  especialidad: '',
+  email: '',
+  telefono: ''
+})
+
+const editForm = reactive({
+  primerNombre: '',
+  segundoNombre: '',
+  apellidoPaterno: '',
+  apellidoMaterno: '',
+  cedula: '',
+  especialidad: '',
+  email: '',
+  telefono: '',
+  activo: true
+})
+
+const hasMedics = computed(() => medics.value.length > 0)
+
+function sanitizeOptional(value: string) {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+async function fetchMedics() {
+  isLoading.value = true
+  loadError.value = null
+
+  try {
+    await store.loadMedics(searchTerm.value, includeInactive.value)
+  } catch (error) {
+    loadError.value =
+      error instanceof Error ? error.message : 'No fue posible obtener el listado de médicos.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function resetNewMedicForm() {
+  newMedic.primerNombre = ''
+  newMedic.segundoNombre = ''
+  newMedic.apellidoPaterno = ''
+  newMedic.apellidoMaterno = ''
+  newMedic.cedula = ''
+  newMedic.especialidad = ''
+  newMedic.email = ''
+  newMedic.telefono = ''
+  creationError.value = null
+}
+
+function startEdit(medic: Medic) {
+  editingMedicId.value = medic.id
+  editForm.primerNombre = medic.primerNombre
+  editForm.segundoNombre = medic.segundoNombre ?? ''
+  editForm.apellidoPaterno = medic.apellidoPaterno
+  editForm.apellidoMaterno = medic.apellidoMaterno ?? ''
+  editForm.cedula = medic.cedula
+  editForm.especialidad = medic.especialidad
+  editForm.email = medic.email
+  editForm.telefono = medic.telefono ?? ''
+  editForm.activo = medic.activo
+  editError.value = null
+}
+
+function cancelEdit() {
+  editingMedicId.value = null
+  editError.value = null
+}
+
+async function handleCreateMedic() {
+  if (savingNewMedic.value) return
+
+  creationError.value = null
+  savingNewMedic.value = true
+
+  const payload: CreateMedicPayload = {
+    primerNombre: newMedic.primerNombre.trim(),
+    segundoNombre: sanitizeOptional(newMedic.segundoNombre),
+    apellidoPaterno: newMedic.apellidoPaterno.trim(),
+    apellidoMaterno: sanitizeOptional(newMedic.apellidoMaterno),
+    cedula: newMedic.cedula.trim(),
+    especialidad: newMedic.especialidad.trim(),
+    email: newMedic.email.trim(),
+    telefono: sanitizeOptional(newMedic.telefono)
+  }
+
+  try {
+    await store.createMedic(payload)
+    resetNewMedicForm()
+    showCreateForm.value = false
+  } catch (error) {
+    creationError.value =
+      error instanceof Error ? error.message : 'No fue posible registrar al médico.'
+  } finally {
+    savingNewMedic.value = false
+  }
+}
+
+async function handleUpdateMedic() {
+  if (savingEdit.value || editingMedicId.value === null) return
+
+  editError.value = null
+  savingEdit.value = true
+
+  const payload: UpdateMedicPayload = {
+    primerNombre: editForm.primerNombre.trim(),
+    segundoNombre: sanitizeOptional(editForm.segundoNombre),
+    apellidoPaterno: editForm.apellidoPaterno.trim(),
+    apellidoMaterno: sanitizeOptional(editForm.apellidoMaterno),
+    cedula: editForm.cedula.trim(),
+    especialidad: editForm.especialidad.trim(),
+    email: editForm.email.trim(),
+    telefono: sanitizeOptional(editForm.telefono),
+    activo: editForm.activo
+  }
+
+  try {
+    await store.updateMedic(editingMedicId.value, payload)
+    editingMedicId.value = null
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible actualizar al médico.'
+  } finally {
+    savingEdit.value = false
+  }
+}
+
+async function handleDeactivateMedic(medic: Medic) {
+  if (actionInProgressId.value || !medic.activo) return
+
+  const confirmDeactivate = window.confirm(
+    `¿Deseas desactivar al Dr(a). ${medic.nombreCompleto}?`
+  )
+
+  if (!confirmDeactivate) {
+    return
+  }
+
+  actionInProgressId.value = medic.id
+
+  try {
+    await store.deactivateMedic(medic.id)
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible desactivar al médico.'
+  } finally {
+    actionInProgressId.value = null
+  }
+}
+
+async function handleReactivateMedic(medic: Medic) {
+  if (actionInProgressId.value || medic.activo) return
+
+  actionInProgressId.value = medic.id
+
+  const payload: UpdateMedicPayload = {
+    primerNombre: medic.primerNombre,
+    segundoNombre: medic.segundoNombre ?? null,
+    apellidoPaterno: medic.apellidoPaterno,
+    apellidoMaterno: medic.apellidoMaterno ?? null,
+    cedula: medic.cedula,
+    especialidad: medic.especialidad,
+    email: medic.email,
+    telefono: medic.telefono ?? null,
+    activo: true
+  }
+
+  try {
+    await store.updateMedic(medic.id, payload)
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible reactivar al médico.'
+  } finally {
+    actionInProgressId.value = null
+  }
+}
+
+function submitSearch() {
+  void fetchMedics()
+}
+
+watch(includeInactive, () => {
+  void fetchMedics()
+})
+
+onMounted(() => {
+  void fetchMedics()
+})
 </script>
 
 <template>
   <section class="space-y-6">
     <header class="space-y-2">
       <h2 class="text-2xl font-semibold text-white">Administrar médicos</h2>
-      <p class="max-w-2xl text-sm text-slate-300/80">
-        Gestiona el catálogo de médicos activos en la clínica. Cada médico puede asociarse a múltiples usuarios del sistema,
-        asegurando que las consultas queden registradas con la persona correcta.
+      <p class="max-w-3xl text-sm text-slate-300/80">
+        Gestiona el catálogo de médicos activos en la clínica. Podrás dar de alta nuevos especialistas, editar su
+        información y controlar si se encuentran disponibles para asignarlos a usuarios y consultas.
       </p>
     </header>
 
-    <div class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-sm text-slate-300/80">
-      <p>
-        Este módulo mostrará próximamente el listado de médicos junto con opciones para agregar nuevos especialistas, editar sus
-        datos de contacto y actualizar la información de su cédula profesional.
-      </p>
-      <p class="mt-3">
-        Mientras tanto, puedes utilizar el script de base de datos actualizado para cargar médicos de ejemplo y vincularlos con
-        los usuarios que tienen asignado el campo <span class="font-semibold text-slate-200">IdMedico</span>.
-      </p>
+    <div class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6">
+      <form class="flex flex-col gap-3 md:flex-row md:items-end" @submit.prevent="submitSearch">
+        <div class="flex-1 space-y-2">
+          <label class="text-xs font-semibold uppercase tracking-wide text-slate-400" for="search-medics"
+            >Buscar</label
+          >
+          <input
+            id="search-medics"
+            v-model="searchTerm"
+            class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+            placeholder="Nombre, cédula o correo"
+            type="search"
+          />
+        </div>
+        <label class="flex items-center gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/50 px-4 py-3 text-xs text-slate-300">
+          <input
+            v-model="includeInactive"
+            class="h-4 w-4 rounded border-slate-700 bg-slate-900 text-sky-500 focus:ring-sky-500"
+            type="checkbox"
+          />
+          Incluir inactivos
+        </label>
+        <button
+          class="rounded-2xl border border-sky-500/60 px-4 py-3 text-sm font-medium text-sky-300 transition hover:bg-sky-500/10"
+          type="submit"
+        >
+          Buscar
+        </button>
+        <button
+          class="rounded-2xl border border-emerald-500/60 px-4 py-3 text-sm font-medium text-emerald-300 transition hover:bg-emerald-500/10"
+          type="button"
+          @click="showCreateForm = !showCreateForm"
+        >
+          {{ showCreateForm ? 'Cerrar formulario' : 'Registrar médico' }}
+        </button>
+      </form>
+
+      <transition name="fade">
+        <div
+          v-if="showCreateForm"
+          class="mt-6 space-y-4 rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 text-sm text-slate-200"
+        >
+          <h3 class="text-base font-semibold text-white">Nuevo médico</h3>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-primer-nombre">Primer nombre</label>
+              <input
+                id="nuevo-primer-nombre"
+                v-model="newMedic.primerNombre"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-segundo-nombre">Segundo nombre</label>
+              <input
+                id="nuevo-segundo-nombre"
+                v-model="newMedic.segundoNombre"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-apellido-paterno">Apellido paterno</label>
+              <input
+                id="nuevo-apellido-paterno"
+                v-model="newMedic.apellidoPaterno"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-apellido-materno">Apellido materno</label>
+              <input
+                id="nuevo-apellido-materno"
+                v-model="newMedic.apellidoMaterno"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-cedula">Cédula profesional</label>
+              <input
+                id="nuevo-cedula"
+                v-model="newMedic.cedula"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-especialidad">Especialidad</label>
+              <input
+                id="nuevo-especialidad"
+                v-model="newMedic.especialidad"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-email">Correo electrónico</label>
+              <input
+                id="nuevo-email"
+                v-model="newMedic.email"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="email"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-telefono">Teléfono</label>
+              <input
+                id="nuevo-telefono"
+                v-model="newMedic.telefono"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="tel"
+              />
+            </div>
+          </div>
+          <p v-if="creationError" class="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+            {{ creationError }}
+          </p>
+          <div class="flex flex-col gap-3 pt-2 text-sm font-medium sm:flex-row">
+            <button
+              class="rounded-2xl border border-emerald-500/60 px-4 py-3 text-emerald-300 transition hover:bg-emerald-500/10 disabled:opacity-60"
+              :disabled="savingNewMedic"
+              type="button"
+              @click="handleCreateMedic"
+            >
+              {{ savingNewMedic ? 'Guardando...' : 'Guardar médico' }}
+            </button>
+            <button
+              class="rounded-2xl border border-slate-700 px-4 py-3 text-slate-300 transition hover:border-slate-500 hover:text-white"
+              type="button"
+              @click="showCreateForm = false"
+            >
+              Cancelar
+            </button>
+          </div>
+        </div>
+      </transition>
+
+      <div class="mt-8 space-y-4">
+        <p v-if="loadError" class="rounded-3xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          {{ loadError }}
+        </p>
+        <p v-else-if="isLoading" class="text-sm text-slate-400">Cargando médicos...</p>
+        <p v-else-if="!hasMedics" class="rounded-3xl border border-slate-800/60 bg-slate-950/60 px-4 py-6 text-sm text-slate-300">
+          No se encontraron médicos con los criterios proporcionados.
+        </p>
+
+        <div v-else class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-200">
+            <thead>
+              <tr class="text-xs uppercase tracking-wide text-slate-400">
+                <th class="px-4 py-3">Nombre</th>
+                <th class="px-4 py-3">Especialidad</th>
+                <th class="px-4 py-3">Cédula</th>
+                <th class="px-4 py-3">Contacto</th>
+                <th class="px-4 py-3">Estado</th>
+                <th class="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800/60">
+              <tr v-for="medic in medics" :key="medic.id" class="hover:bg-slate-900/40">
+                <td class="px-4 py-3">
+                  <p class="font-semibold text-white">{{ medic.nombreCompleto }}</p>
+                  <p class="text-xs text-slate-400">{{ medic.email }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="text-sm text-slate-200">{{ medic.especialidad }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="text-sm text-slate-200">{{ medic.cedula }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="text-sm text-slate-200">{{ medic.telefono || 'Sin teléfono' }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <span
+                    class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
+                    :class="medic.activo ? 'bg-emerald-500/10 text-emerald-300' : 'bg-slate-700/40 text-slate-300'"
+                  >
+                    {{ medic.activo ? 'Activo' : 'Inactivo' }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <div class="flex flex-wrap items-center justify-end gap-2 text-xs font-medium">
+                    <button
+                      class="rounded-2xl border border-slate-700 px-3 py-2 text-slate-200 transition hover:border-sky-500/60 hover:text-sky-300"
+                      type="button"
+                      @click="startEdit(medic)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      v-if="medic.activo"
+                      class="rounded-2xl border border-rose-500/40 px-3 py-2 text-rose-300 transition hover:bg-rose-500/10 disabled:opacity-60"
+                      :disabled="actionInProgressId === medic.id"
+                      type="button"
+                      @click="handleDeactivateMedic(medic)"
+                    >
+                      {{ actionInProgressId === medic.id ? 'Procesando...' : 'Desactivar' }}
+                    </button>
+                    <button
+                      v-else
+                      class="rounded-2xl border border-emerald-500/60 px-3 py-2 text-emerald-300 transition hover:bg-emerald-500/10 disabled:opacity-60"
+                      :disabled="actionInProgressId === medic.id"
+                      type="button"
+                      @click="handleReactivateMedic(medic)"
+                    >
+                      {{ actionInProgressId === medic.id ? 'Procesando...' : 'Reactivar' }}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
+
+    <transition name="fade">
+      <div
+        v-if="editingMedicId !== null"
+        class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-sm text-slate-200"
+      >
+        <header class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="text-lg font-semibold text-white">Editar médico</h3>
+            <p class="text-xs text-slate-400">Actualiza los datos antes de guardar los cambios.</p>
+          </div>
+          <button class="text-xs text-slate-400 hover:text-white" type="button" @click="cancelEdit">Cerrar</button>
+        </header>
+
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-primer-nombre">Primer nombre</label>
+            <input
+              id="editar-primer-nombre"
+              v-model="editForm.primerNombre"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-segundo-nombre">Segundo nombre</label>
+            <input
+              id="editar-segundo-nombre"
+              v-model="editForm.segundoNombre"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-apellido-paterno">Apellido paterno</label>
+            <input
+              id="editar-apellido-paterno"
+              v-model="editForm.apellidoPaterno"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-apellido-materno">Apellido materno</label>
+            <input
+              id="editar-apellido-materno"
+              v-model="editForm.apellidoMaterno"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-cedula">Cédula profesional</label>
+            <input
+              id="editar-cedula"
+              v-model="editForm.cedula"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-especialidad">Especialidad</label>
+            <input
+              id="editar-especialidad"
+              v-model="editForm.especialidad"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-email">Correo electrónico</label>
+            <input
+              id="editar-email"
+              v-model="editForm.email"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="email"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-telefono">Teléfono</label>
+            <input
+              id="editar-telefono"
+              v-model="editForm.telefono"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="tel"
+            />
+          </div>
+          <label class="flex items-center gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-3 text-xs text-slate-300">
+            <input
+              v-model="editForm.activo"
+              class="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+              type="checkbox"
+            />
+            Médico activo
+          </label>
+        </div>
+
+        <p v-if="editError" class="mt-4 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+          {{ editError }}
+        </p>
+
+        <div class="mt-6 flex flex-col gap-3 text-sm font-medium sm:flex-row">
+          <button
+            class="rounded-2xl border border-sky-500/60 px-4 py-3 text-sky-300 transition hover:bg-sky-500/10 disabled:opacity-60"
+            :disabled="savingEdit"
+            type="button"
+            @click="handleUpdateMedic"
+          >
+            {{ savingEdit ? 'Guardando...' : 'Guardar cambios' }}
+          </button>
+          <button
+            class="rounded-2xl border border-slate-700 px-4 py-3 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            type="button"
+            @click="cancelEdit"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </transition>
   </section>
 </template>

--- a/frontend/src/views/admin/UsersAdminView.vue
+++ b/frontend/src/views/admin/UsersAdminView.vue
@@ -1,25 +1,486 @@
 <script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useAdminStore } from '../../stores/adminStore'
+import type { CreateUserPayload, UpdateUserPayload, UserAccount } from '../../types'
+
+const store = useAdminStore()
+const users = store.users
+const medics = store.medics
+
+const searchTerm = ref('')
+const includeInactive = ref(false)
+const isLoading = ref(false)
+const loadError = ref<string | null>(null)
+const showCreateForm = ref(false)
+const creationError = ref<string | null>(null)
+const savingNewUser = ref(false)
+const editingUserId = ref<number | null>(null)
+const editError = ref<string | null>(null)
+const savingEdit = ref(false)
+const actionInProgressId = ref<number | null>(null)
+
+const newUser = reactive({
+  correo: '',
+  nombreCompleto: '',
+  password: '',
+  medicoId: '' as '' | number,
+  activo: true
+})
+
+const editForm = reactive({
+  correo: '',
+  nombreCompleto: '',
+  password: '',
+  medicoId: '' as '' | number,
+  activo: true
+})
+
+const availableMedics = computed(() => medics.value.filter((medic) => medic.activo))
+const hasUsers = computed(() => users.value.length > 0)
+
+function normalizeMedicoId(value: '' | number): number | null {
+  if (value === '' || value === null) {
+    return null
+  }
+  const parsed = Number(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+async function fetchUsers() {
+  isLoading.value = true
+  loadError.value = null
+
+  try {
+    await store.loadUsers(searchTerm.value, includeInactive.value)
+  } catch (error) {
+    loadError.value =
+      error instanceof Error ? error.message : 'No fue posible obtener el listado de usuarios.'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function resetNewUserForm() {
+  newUser.correo = ''
+  newUser.nombreCompleto = ''
+  newUser.password = ''
+  newUser.medicoId = ''
+  newUser.activo = true
+  creationError.value = null
+}
+
+function startEdit(user: UserAccount) {
+  editingUserId.value = user.id
+  editForm.correo = user.correo
+  editForm.nombreCompleto = user.nombreCompleto
+  editForm.password = ''
+  editForm.medicoId = user.medicoId ?? ''
+  editForm.activo = user.activo
+  editError.value = null
+}
+
+function cancelEdit() {
+  editingUserId.value = null
+  editError.value = null
+}
+
+async function handleCreateUser() {
+  if (savingNewUser.value) return
+
+  creationError.value = null
+  savingNewUser.value = true
+
+  const payload: CreateUserPayload = {
+    correo: newUser.correo.trim(),
+    password: newUser.password,
+    nombreCompleto: newUser.nombreCompleto.trim(),
+    medicoId: normalizeMedicoId(newUser.medicoId),
+    activo: newUser.activo
+  }
+
+  try {
+    await store.createUser(payload)
+    resetNewUserForm()
+    showCreateForm.value = false
+  } catch (error) {
+    creationError.value =
+      error instanceof Error ? error.message : 'No fue posible registrar al usuario.'
+  } finally {
+    savingNewUser.value = false
+  }
+}
+
+async function handleUpdateUser() {
+  if (savingEdit.value || editingUserId.value === null) return
+
+  editError.value = null
+  savingEdit.value = true
+
+  const passwordValue = editForm.password.trim()
+
+  const payload: UpdateUserPayload = {
+    correo: editForm.correo.trim(),
+    password: passwordValue.length > 0 ? passwordValue : null,
+    nombreCompleto: editForm.nombreCompleto.trim(),
+    medicoId: normalizeMedicoId(editForm.medicoId),
+    activo: editForm.activo
+  }
+
+  try {
+    await store.updateUser(editingUserId.value, payload)
+    editingUserId.value = null
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible actualizar al usuario.'
+  } finally {
+    savingEdit.value = false
+  }
+}
+
+async function handleDeactivateUser(user: UserAccount) {
+  if (actionInProgressId.value || !user.activo) return
+
+  const confirmDeactivate = window.confirm(`¿Deseas desactivar la cuenta ${user.correo}?`)
+  if (!confirmDeactivate) {
+    return
+  }
+
+  actionInProgressId.value = user.id
+
+  try {
+    await store.deactivateUser(user.id)
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible desactivar al usuario.'
+  } finally {
+    actionInProgressId.value = null
+  }
+}
+
+async function handleReactivateUser(user: UserAccount) {
+  if (actionInProgressId.value || user.activo) return
+
+  actionInProgressId.value = user.id
+
+  const payload: UpdateUserPayload = {
+    correo: user.correo,
+    password: null,
+    nombreCompleto: user.nombreCompleto,
+    medicoId: user.medicoId ?? null,
+    activo: true
+  }
+
+  try {
+    await store.updateUser(user.id, payload)
+  } catch (error) {
+    editError.value =
+      error instanceof Error ? error.message : 'No fue posible reactivar al usuario.'
+  } finally {
+    actionInProgressId.value = null
+  }
+}
+
+function submitSearch() {
+  void fetchUsers()
+}
+
+watch(includeInactive, () => {
+  void fetchUsers()
+})
+
+onMounted(() => {
+  void store.loadMedics('', true).catch(() => undefined)
+  void fetchUsers()
+})
 </script>
 
 <template>
   <section class="space-y-6">
     <header class="space-y-2">
       <h2 class="text-2xl font-semibold text-white">Administrar usuarios</h2>
-      <p class="max-w-2xl text-sm text-slate-300/80">
-        Desde este módulo podrás consultar, crear, actualizar y desactivar cuentas de acceso para el personal de la clínica.
-        Vincula los usuarios con el catálogo de médicos cuando corresponda.
+      <p class="max-w-3xl text-sm text-slate-300/80">
+        Consulta, crea y actualiza las cuentas del personal. Asigna un médico cuando corresponda y controla si la cuenta puede
+        acceder al sistema.
       </p>
     </header>
 
-    <div class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-sm text-slate-300/80">
-      <p>
-        El desarrollo del CRUD se encuentra en progreso. Mientras tanto, puedes revisar la configuración de usuarios desde la
-        base de datos y vincularlos con médicos usando el campo <span class="font-semibold text-slate-200">IdMedico</span>.
-      </p>
-      <p class="mt-3">
-        Una vez que se integren los servicios correspondientes, aquí verás la tabla de usuarios con opciones para crear nuevos
-        accesos y editar los existentes.
-      </p>
+    <div class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6">
+      <form class="flex flex-col gap-3 md:flex-row md:items-end" @submit.prevent="submitSearch">
+        <div class="flex-1 space-y-2">
+          <label class="text-xs font-semibold uppercase tracking-wide text-slate-400" for="search-users"
+            >Buscar</label
+          >
+          <input
+            id="search-users"
+            v-model="searchTerm"
+            class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+            placeholder="Correo o nombre completo"
+            type="search"
+          />
+        </div>
+        <label class="flex items-center gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/50 px-4 py-3 text-xs text-slate-300">
+          <input
+            v-model="includeInactive"
+            class="h-4 w-4 rounded border-slate-700 bg-slate-900 text-sky-500 focus:ring-sky-500"
+            type="checkbox"
+          />
+          Incluir inactivos
+        </label>
+        <button
+          class="rounded-2xl border border-sky-500/60 px-4 py-3 text-sm font-medium text-sky-300 transition hover:bg-sky-500/10"
+          type="submit"
+        >
+          Buscar
+        </button>
+        <button
+          class="rounded-2xl border border-emerald-500/60 px-4 py-3 text-sm font-medium text-emerald-300 transition hover:bg-emerald-500/10"
+          type="button"
+          @click="showCreateForm = !showCreateForm"
+        >
+          {{ showCreateForm ? 'Cerrar formulario' : 'Crear usuario' }}
+        </button>
+      </form>
+
+      <transition name="fade">
+        <div
+          v-if="showCreateForm"
+          class="mt-6 space-y-4 rounded-3xl border border-slate-800/60 bg-slate-950/60 p-6 text-sm text-slate-200"
+        >
+          <h3 class="text-base font-semibold text-white">Nuevo usuario</h3>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-correo">Correo electrónico</label>
+              <input
+                id="nuevo-correo"
+                v-model="newUser.correo"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="email"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-nombre">Nombre completo</label>
+              <input
+                id="nuevo-nombre"
+                v-model="newUser.nombreCompleto"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="text"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-password">Contraseña</label>
+              <input
+                id="nuevo-password"
+                v-model="newUser.password"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                type="password"
+              />
+            </div>
+            <div class="space-y-2">
+              <label class="text-xs font-medium text-slate-300" for="nuevo-medico">Médico asignado (opcional)</label>
+              <select
+                id="nuevo-medico"
+                v-model="newUser.medicoId"
+                class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+              >
+                <option value="">Sin asignar</option>
+                <option v-for="medic in availableMedics" :key="medic.id" :value="medic.id">
+                  {{ medic.nombreCompleto }}
+                </option>
+              </select>
+            </div>
+            <label class="flex items-center gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-3 text-xs text-slate-300">
+              <input
+                v-model="newUser.activo"
+                class="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+                type="checkbox"
+              />
+              Usuario activo
+            </label>
+          </div>
+          <p v-if="creationError" class="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+            {{ creationError }}
+          </p>
+          <div class="flex flex-col gap-3 pt-2 text-sm font-medium sm:flex-row">
+            <button
+              class="rounded-2xl border border-emerald-500/60 px-4 py-3 text-emerald-300 transition hover:bg-emerald-500/10 disabled:opacity-60"
+              :disabled="savingNewUser"
+              type="button"
+              @click="handleCreateUser"
+            >
+              {{ savingNewUser ? 'Guardando...' : 'Guardar usuario' }}
+            </button>
+            <button
+              class="rounded-2xl border border-slate-700 px-4 py-3 text-slate-300 transition hover:border-slate-500 hover:text-white"
+              type="button"
+              @click="showCreateForm = false"
+            >
+              Cancelar
+            </button>
+          </div>
+        </div>
+      </transition>
+
+      <div class="mt-8 space-y-4">
+        <p v-if="loadError" class="rounded-3xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          {{ loadError }}
+        </p>
+        <p v-else-if="isLoading" class="text-sm text-slate-400">Cargando usuarios...</p>
+        <p v-else-if="!hasUsers" class="rounded-3xl border border-slate-800/60 bg-slate-950/60 px-4 py-6 text-sm text-slate-300">
+          No se encontraron usuarios con los criterios indicados.
+        </p>
+
+        <div v-else class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-slate-800 text-left text-sm text-slate-200">
+            <thead>
+              <tr class="text-xs uppercase tracking-wide text-slate-400">
+                <th class="px-4 py-3">Correo</th>
+                <th class="px-4 py-3">Nombre</th>
+                <th class="px-4 py-3">Médico asignado</th>
+                <th class="px-4 py-3">Estado</th>
+                <th class="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-800/60">
+              <tr v-for="user in users" :key="user.id" class="hover:bg-slate-900/40">
+                <td class="px-4 py-3">
+                  <p class="font-semibold text-white">{{ user.correo }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="text-sm text-slate-200">{{ user.nombreCompleto }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <p class="text-sm text-slate-200">{{ user.medicoNombreCompleto || 'Sin asignar' }}</p>
+                </td>
+                <td class="px-4 py-3">
+                  <span
+                    class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
+                    :class="user.activo ? 'bg-emerald-500/10 text-emerald-300' : 'bg-slate-700/40 text-slate-300'"
+                  >
+                    {{ user.activo ? 'Activo' : 'Inactivo' }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <div class="flex flex-wrap items-center justify-end gap-2 text-xs font-medium">
+                    <button
+                      class="rounded-2xl border border-slate-700 px-3 py-2 text-slate-200 transition hover:border-sky-500/60 hover:text-sky-300"
+                      type="button"
+                      @click="startEdit(user)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      v-if="user.activo"
+                      class="rounded-2xl border border-rose-500/40 px-3 py-2 text-rose-300 transition hover:bg-rose-500/10 disabled:opacity-60"
+                      :disabled="actionInProgressId === user.id"
+                      type="button"
+                      @click="handleDeactivateUser(user)"
+                    >
+                      {{ actionInProgressId === user.id ? 'Procesando...' : 'Desactivar' }}
+                    </button>
+                    <button
+                      v-else
+                      class="rounded-2xl border border-emerald-500/60 px-3 py-2 text-emerald-300 transition hover:bg-emerald-500/10 disabled:opacity-60"
+                      :disabled="actionInProgressId === user.id"
+                      type="button"
+                      @click="handleReactivateUser(user)"
+                    >
+                      {{ actionInProgressId === user.id ? 'Procesando...' : 'Reactivar' }}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
+
+    <transition name="fade">
+      <div
+        v-if="editingUserId !== null"
+        class="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-sm text-slate-200"
+      >
+        <header class="flex items-start justify-between gap-4">
+          <div>
+            <h3 class="text-lg font-semibold text-white">Editar usuario</h3>
+            <p class="text-xs text-slate-400">Modifica los datos de acceso o su estado.</p>
+          </div>
+          <button class="text-xs text-slate-400 hover:text-white" type="button" @click="cancelEdit">Cerrar</button>
+        </header>
+
+        <div class="mt-4 grid gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-correo">Correo electrónico</label>
+            <input
+              id="editar-correo"
+              v-model="editForm.correo"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="email"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-nombre">Nombre completo</label>
+            <input
+              id="editar-nombre"
+              v-model="editForm.nombreCompleto"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="text"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-password">Nueva contraseña (opcional)</label>
+            <input
+              id="editar-password"
+              v-model="editForm.password"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+              type="password"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-medium text-slate-300" for="editar-medico">Médico asignado</label>
+            <select
+              id="editar-medico"
+              v-model="editForm.medicoId"
+              class="w-full rounded-2xl border border-slate-700 bg-slate-950/70 px-4 py-3 text-sm text-white focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+            >
+              <option value="">Sin asignar</option>
+              <option v-for="medic in medics" :key="medic.id" :value="medic.id">
+                {{ medic.nombreCompleto }}
+              </option>
+            </select>
+          </div>
+          <label class="flex items-center gap-2 rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-3 text-xs text-slate-300">
+            <input
+              v-model="editForm.activo"
+              class="h-4 w-4 rounded border-slate-700 bg-slate-900 text-emerald-500 focus:ring-emerald-500"
+              type="checkbox"
+            />
+            Usuario activo
+          </label>
+        </div>
+
+        <p v-if="editError" class="mt-4 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+          {{ editError }}
+        </p>
+
+        <div class="mt-6 flex flex-col gap-3 text-sm font-medium sm:flex-row">
+          <button
+            class="rounded-2xl border border-sky-500/60 px-4 py-3 text-sky-300 transition hover:bg-sky-500/10 disabled:opacity-60"
+            :disabled="savingEdit"
+            type="button"
+            @click="handleUpdateUser"
+          >
+            {{ savingEdit ? 'Guardando...' : 'Guardar cambios' }}
+          </button>
+          <button
+            class="rounded-2xl border border-slate-700 px-4 py-3 text-slate-300 transition hover:border-slate-500 hover:text-white"
+            type="button"
+            @click="cancelEdit"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </transition>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- add API endpoints and helpers for managing medics and user accounts in the backend, including validation and hashing utilities
- expose medic and user CRUD services and store logic in the frontend and replace admin views with full-featured management UIs
- extend the SQL deployment script with stored procedures that cover medic and user CRUD operations alongside existing data

## Testing
- `dotnet build` *(fails: dotnet CLI not available in the execution environment)*
- `npm run build` *(fails: vue-tsc cannot locate supportedTSExtensions pattern in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e03858c75c832c8826b61567d7d044