### PR TITLE
Fix lambda optional parameter order in Program.cs

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -167,7 +167,7 @@ app.MapPost("/auth/login", async (LoginRequest request, SqlConnection connection
     return Results.Ok(respuesta);
 });
 
-app.MapGet("/medics", async (string? search, bool includeInactive = false, SqlConnection connection, CancellationToken cancellationToken) =>
+app.MapGet("/medics", async (string? search, SqlConnection connection, CancellationToken cancellationToken, bool includeInactive = false) =>
 {
     var medicos = new List<MedicDto>();
     var searchTerm = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
@@ -435,7 +435,7 @@ app.MapDelete("/medics/{id:int}", async (int id, SqlConnection connection, Cance
         : Results.NotFound(new { message = "Médico no encontrado." });
 });
 
-app.MapGet("/users", async (string? search, bool includeInactive = false, SqlConnection connection, CancellationToken cancellationToken) =>
+app.MapGet("/users", async (string? search, SqlConnection connection, CancellationToken cancellationToken, bool includeInactive = false) =>
 {
     var usuarios = new List<UserDto>();
     var searchTerm = string.IsNullOrWhiteSpace(search) ? null : search.Trim();


### PR DESCRIPTION
## Summary
- move the optional includeInactive parameters to the end of the minimal API lambda signatures to avoid preview language features

## Testing
- dotnet build Backend.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e03d0d7fd0832c9127e9f579fe0325