### PR TITLE
Add Magica branding to dashboard and favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Frontend Vue 3</title>
   </head>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="16" fill="#1E3A8A"/>
+  <path d="M12 20C12 15.5817 15.5817 12 20 12H32C36.4183 12 40 15.5817 40 20V48H20C15.5817 48 12 44.4183 12 40V20Z" fill="#FBBF24"/>
+  <text x="32" y="42" text-anchor="middle" fill="white" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="28" font-style="italic" font-weight="700">M</text>
+</svg>

--- a/frontend/src/assets/logo-magica.svg
+++ b/frontend/src/assets/logo-magica.svg
@@ -1,0 +1,5 @@
+<svg width="220" height="80" viewBox="0 0 220 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="80" rx="16" fill="#1E3A8A"/>
+  <path d="M28 22C28 17.5817 31.5817 14 36 14H70C74.4183 14 78 17.5817 78 22V58H36C31.5817 58 28 54.4183 28 50V22Z" fill="#FBBF24"/>
+  <text x="86" y="50" fill="white" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="36" font-style="italic" font-weight="700">Magica</text>
+</svg>

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -61,10 +61,17 @@ const navigation = [
   <div class="min-h-screen bg-slate-950 text-slate-100">
     <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur">
       <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-6 px-6 py-6">
-        <div>
-          <p class="text-sm uppercase tracking-[0.35em] text-sky-400/80">Clínica Mágica</p>
-          <h1 class="mt-1 text-2xl font-semibold text-white">{{ userGreeting }}</h1>
-          <p class="mt-1 max-w-2xl text-sm text-slate-300/80">{{ motivationalPhrase }}</p>
+        <div class="flex items-center gap-6">
+          <img
+            src="@/assets/logo-magica.svg"
+            alt="Logotipo de Magica"
+            class="h-12 w-auto drop-shadow-lg"
+          />
+          <div>
+            <p class="text-sm uppercase tracking-[0.35em] text-sky-400/80">Clínica Mágica</p>
+            <h1 class="mt-1 text-2xl font-semibold text-white">{{ userGreeting }}</h1>
+            <p class="mt-1 max-w-2xl text-sm text-slate-300/80">{{ motivationalPhrase }}</p>
+          </div>
         </div>
         <button
           class="inline-flex items-center gap-2 rounded-full border border-slate-700/60 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-rose-400/60 hover:text-rose-200"


### PR DESCRIPTION
## Summary
- add a Magica-branded logo asset and surface it in the dashboard header
- replace the default Vite favicon with a Magica "M" variant

## Testing
- npm run build *(fails: Search string not found: "/supportedTSExtensions = .*(?=;)/")*


------
https://chatgpt.com/codex/tasks/task_e_68e04d7a2218832c90db2d9756c5fc57